### PR TITLE
added blog post on capsule net and custom TF op

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Your feedback and contributions are always welcome!
 - [Matrix capsules with EM routing](https://blog.acolyer.org/2017/11/14/matrix-capsules-with-em-routing/) - Adrian Colyer's post on EM routing
 - [Capsule Networks: A Glossary](http://www.aisummary.com/blog/capsule-networks-glossary/) - Sebastian Kwiatkowski's glossary
 - [Overview of awesome articles](http://www.aisummary.com/blog/three-complementary-capsule-network-tutorials/)
+- [Cuda, TensorFlow and Capsule Networks](http://jostosh.github.io/posts/capscuda.html) - Jos van de Wolfshaar
 
 ## Dynamic routing implementations
 


### PR DESCRIPTION
Concerns a blog post I wrote on implementing the 'capsule prediction operation' with a custom TF op. You can find it here http://jostosh.github.io/posts/capscuda.html.